### PR TITLE
Replace get_plugin_name with the actual name.

### DIFF
--- a/bin/lib/functions.sh
+++ b/bin/lib/functions.sh
@@ -1,7 +1,7 @@
 # USAGE: athena.plugins.proxy.get_container_name [<port>]
 function athena.plugins.proxy.get_container_name()
 {
-	local container_name="$(athena.os.get_prefix)-plugin-$(athena.plugin.get_plugin)-$(athena.os.get_instance)"
+	local container_name="$(athena.os.get_prefix)-plugin-proxy-$(athena.os.get_instance)"
 
 	if [[ -n "$1" ]]; then
 		container_name="${container_name}-${1}"

--- a/tests/test.functions.sh
+++ b/tests/test.functions.sh
@@ -3,9 +3,8 @@ athena.plugin.require "proxy"
 function testcase_athena.plugins.proxy.get_container_name()
 {
 	athena.test.mock.outputs "athena.os.get_prefix" "myprefix"
-	athena.test.mock.outputs "athena.plugin.get_plugin" "myplugin"
 	athena.test.mock.outputs "athena.os.get_instance" "1"
 
-	athena.test.assert_output "athena.plugins.proxy.get_container_name" "myprefix-plugin-myplugin-1-5001" "5001"
-	athena.test.assert_output "athena.plugins.proxy.get_container_name" "myprefix-plugin-myplugin-1"
+	athena.test.assert_output "athena.plugins.proxy.get_container_name" "myprefix-plugin-proxy-1-5001" "5001"
+	athena.test.assert_output "athena.plugins.proxy.get_container_name" "myprefix-plugin-proxy-1"
 }


### PR DESCRIPTION
When including proxy plugin inside another plugin, get_plugin method
receives not "proxy" but the other plugin name.
